### PR TITLE
[FEAT] Update Subscription event's status

### DIFF
--- a/src/hooks/services/hooks.service.spec.ts
+++ b/src/hooks/services/hooks.service.spec.ts
@@ -15,6 +15,8 @@ import {
   BanksUserTransaction,
   BanksUserTransactionType,
   IServiceAccount,
+  SubscriptionEvent,
+  ISubscriptionEvent,
 } from '@algoan/rest';
 import { EventDTO } from '../dto/event.dto';
 import { AggregatorModule } from '../../aggregator/aggregator.module';
@@ -107,6 +109,9 @@ describe('HooksService', () => {
 
   describe('handleWebhook calls the correct event handling function', () => {
     beforeEach(() => {
+      jest
+        .spyOn(SubscriptionEvent.prototype, 'update')
+        .mockResolvedValue(({} as unknown) as ISubscriptionEvent & { id: string });
       jest.spyOn(algoanService.algoanClient, 'getServiceAccountBySubscriptionId').mockReturnValue(mockServiceAccount);
     });
     it('handles bankreader link required', async () => {

--- a/test/hooks.e2e-spec.ts
+++ b/test/hooks.e2e-spec.ts
@@ -1,6 +1,9 @@
 import { INestApplication, HttpStatus } from '@nestjs/common';
+import * as assert from 'assert';
+import * as nock from 'nock';
 import * as request from 'supertest';
-import { buildFakeApp } from './utils/app';
+import { buildFakeApp, fakeAlgoanBaseUrl } from './utils/app';
+import { fakeAPI } from './utils/fake-server';
 
 describe('HooksController (e2e)', () => {
   let app: INestApplication;
@@ -48,7 +51,15 @@ describe('HooksController (e2e)', () => {
     });
 
     it('HK004 - should be ok', async () => {
-      return request(app.getHttpServer())
+      const fakeSubEventServer: nock.Scope = fakeAPI({
+        baseUrl: fakeAlgoanBaseUrl,
+        method: 'patch',
+        result: {},
+        path: '/v1/subscriptions/1/events/random',
+        nbOfCalls: 1,
+      });
+
+      await request(app.getHttpServer())
         .post('/hooks')
         .send({
           subscription: {
@@ -66,6 +77,8 @@ describe('HooksController (e2e)', () => {
           },
         })
         .expect(HttpStatus.NO_CONTENT);
+
+      assert.equal(fakeSubEventServer.isDone(), true);
     });
   });
 });


### PR DESCRIPTION
### Description

- Update SubscriptionEvent status at:
  - Reception: `ACK` (acknowledgement)
  - Error: `ERROR`
  - Failure: `FAILED` (should not happen, the event is not recognized by the connector)

### Reference

- Documentation [PATCH Resthook Subscription Event](https://developers.algoan.com/api#operation/patchResthookSubEvents)