### PR TITLE
feat: use winston logger when calling Algoan

### DIFF
--- a/src/algoan/algoan.service.ts
+++ b/src/algoan/algoan.service.ts
@@ -1,7 +1,9 @@
 import { Algoan, EventName } from '@algoan/rest';
 import { Injectable, OnModuleInit, InternalServerErrorException, Logger } from '@nestjs/common';
 import { isEmpty } from 'lodash';
+import { utilities } from 'nest-winston';
 import { config } from 'node-config-ts';
+import { format, transports } from 'winston';
 
 /**
  * Algoan service
@@ -23,6 +25,9 @@ export class AlgoanService implements OnModuleInit {
    * Fetch services and creates subscription
    */
   public async onModuleInit(): Promise<void> {
+    const defaultLevel: string = process.env.DEBUG_LEVEL ?? 'info';
+    const nodeEnv: string | undefined = process.env.NODE_ENV;
+
     /**
      * Retrieve service accounts and get/create subscriptions
      */
@@ -31,6 +36,19 @@ export class AlgoanService implements OnModuleInit {
       clientId: config.algoan.clientId,
       clientSecret: config.algoan.clientSecret,
       debug: config.algoan.debug,
+      loggerOptions: {
+        format:
+          nodeEnv === 'production' ? format.json() : format.combine(format.timestamp(), utilities.format.nestLike()),
+        level: defaultLevel,
+        transports: [
+          new transports.Console({
+            level: defaultLevel,
+            stderrLevels: ['error'],
+            consoleWarnLevels: ['warning'],
+            silent: nodeEnv === 'test',
+          }),
+        ],
+      },
     });
 
     if (isEmpty(config.eventList)) {


### PR DESCRIPTION
### Description

- Set @algoan/rest to use the same Winston Logger config than the rest of the connector 