### PR TITLE
[FEAT] Respond 204 before handling webhook event

### DIFF
--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -60,13 +60,28 @@ export class HooksService {
       throw new UnauthorizedException('Invalid X-Hub-Signature: you cannot call this API');
     }
 
+    // Handle the event asynchronously
+    void this.dispatchAndHandleWebhook(event, subscription, serviceAccount);
+
+    return;
+  }
+
+  /**
+   * Dispatch to the right webhook handler and handle
+   *
+   * Allow to asynchronously handle (with `void`) the webhook and firstly respond 204 to the server
+   */
+  private async dispatchAndHandleWebhook(
+    event: EventDTO,
+    subscription: Subscription,
+    serviceAccount: ServiceAccount,
+  ): Promise<void> {
     // ACKnowledge the subscription event
     const se: SubscriptionEvent = subscription.event(event.id);
 
     try {
       switch (event.subscription.eventName) {
         case EventName.BANKREADER_LINK_REQUIRED:
-          // @ts-ignore
           await this.handleBankreaderLinkRequiredEvent(serviceAccount, event.payload as BankreaderLinkRequiredDTO);
           break;
 
@@ -90,8 +105,6 @@ export class HooksService {
     }
 
     void se.update({ status: EventStatus.PROCESSED });
-
-    return;
   }
 
   /**


### PR DESCRIPTION
### Description

- Respond `204 No Content` before handling webhook event to prevent the server from taking it as a failure as account and transaction aggregation may take more than 5 seconds for some accounts.

### Reference

- [REST Hooks documentation](https://stg-docs.int.algoan.net/public/docs/algoan_documentation/resthooks_and_events/resthooks.html#required-204-ok-response)