### PR TITLE
[FEAT] Get all the synchronised transactions

### DIFF
--- a/config/env/test.json
+++ b/config/env/test.json
@@ -3,7 +3,8 @@
     "service_account_created"
   ],
   "bridge":{
-    "synchronizationWaitingTime": 0
+    "synchronizationWaitingTime": 0,
+    "synchronizationTimeout": 0
   },
   "banksUserIdPassword": "random_pass"
 }

--- a/src/aggregator/services/aggregator.service.spec.ts
+++ b/src/aggregator/services/aggregator.service.spec.ts
@@ -149,9 +149,9 @@ describe('AggregatorService', () => {
   it('should get the transactions', async () => {
     const spy = jest.spyOn(client, 'getTransactions').mockReturnValue(Promise.resolve([mockTransaction]));
     const token = 'token';
-    await service.getTransactions(token);
+    await service.getTransactions(token, undefined);
 
-    expect(spy).toBeCalledWith(token, undefined);
+    expect(spy).toBeCalledWith(token, undefined, undefined);
   });
 
   it('should get the accessToken', async () => {

--- a/src/aggregator/services/aggregator.service.ts
+++ b/src/aggregator/services/aggregator.service.ts
@@ -58,8 +58,12 @@ export class AggregatorService {
    * Returns the Bridge Transactions for an account
    *
    */
-  public async getTransactions(accessToken: string, clientConfig?: ClientConfig): Promise<BridgeTransaction[]> {
-    return this.bridgeClient.getTransactions(accessToken, clientConfig);
+  public async getTransactions(
+    accessToken: string,
+    lastUpdatedAt: string | undefined,
+    clientConfig?: ClientConfig,
+  ): Promise<BridgeTransaction[]> {
+    return this.bridgeClient.getTransactions(accessToken, clientConfig, lastUpdatedAt);
   }
 
   /**

--- a/src/aggregator/services/bridge/bridge.client.spec.ts
+++ b/src/aggregator/services/bridge/bridge.client.spec.ts
@@ -261,7 +261,7 @@ describe('BridgeClient', () => {
     const resp = await service.getTransactions('secret-access-token');
     expect(resp).toEqual(listAccountTransactionsResponse.resources);
 
-    expect(spy).toHaveBeenCalledWith(`https://sync.bankin.com/v2/transactions?limit=100`, {
+    expect(spy).toHaveBeenCalledWith(`https://sync.bankin.com/v2/transactions/updated?limit=100`, {
       headers: {
         Authorization: 'Bearer secret-access-token',
         'Client-Id': config.bridge.clientId,

--- a/src/hooks/services/hooks.service.spec.ts
+++ b/src/hooks/services/hooks.service.spec.ts
@@ -204,7 +204,7 @@ describe('HooksService', () => {
     expect(accountSpy).toBeCalledWith('mockPermToken', mockServiceAccountConfig);
     expect(resourceNameSpy).toBeCalledWith('mockPermToken', mockAccount.bank.resource_uri, mockServiceAccountConfig);
     expect(banksUserAccountSpy).toBeCalledWith(mappedAccount);
-    expect(transactionSpy).toBeCalledWith('mockPermToken', mockServiceAccountConfig);
+    expect(transactionSpy).toBeCalledWith('mockPermToken', undefined, mockServiceAccountConfig);
     expect(resourceNameSpy).toBeCalledWith(
       'mockPermToken',
       mockTransaction.category.resource_uri,


### PR DESCRIPTION
## [FEAT] Get all the synchronised transactions
### Description
Try to get all synchronised transactions after a timeout and on the basis of the field `updated_at` of the last updated transaction.

TODOS before it is ready for reviewing :

- [x]  Validate the workflow
- [x]  Test locally 
- [x]  Adjust automatic tests