### PR TITLE
[FEAT] Fetch user personal information

### DIFF
--- a/src/aggregator/interfaces/bridge-mock.ts
+++ b/src/aggregator/interfaces/bridge-mock.ts
@@ -101,7 +101,7 @@ export const mockPersonalInformation: BridgeUserInformation[] = [
     nb_kids: 0,
   },
   {
-    item_id: 1234568,
+    item_id: 5,
     sex: 'MALE',
     first_name: null, // eslint-disable-line no-null/no-null
     last_name: 'DUPONT',

--- a/src/aggregator/interfaces/bridge-mock.ts
+++ b/src/aggregator/interfaces/bridge-mock.ts
@@ -5,6 +5,7 @@ import {
   BridgeTransaction,
   UserResponse,
   AuthenticationResponse,
+  BridgeUserInformation,
 } from './bridge.interface';
 
 export const mockAccount: BridgeAccount = {
@@ -82,3 +83,36 @@ export const mockAuthResponse: AuthenticationResponse = {
   access_token: 'mockAccessToken',
   expires_at: 'mockDate',
 };
+
+export const mockPersonalInformation: BridgeUserInformation[] = [
+  {
+    item_id: 1234567,
+    sex: 'MALE',
+    first_name: 'MICHEL',
+    last_name: 'DUPONT',
+    zip: '75001',
+    address: '7 RUE DES MOULINS 75001 PARIS FRANCE',
+    birthday: '1980-08-26',
+    job: null, // eslint-disable-line no-null/no-null
+    job_category: null, // eslint-disable-line no-null/no-null
+    job_category_details: null, // eslint-disable-line no-null/no-null
+    is_married: true,
+    is_owner: false,
+    nb_kids: 0,
+  },
+  {
+    item_id: 1234568,
+    sex: 'MALE',
+    first_name: null, // eslint-disable-line no-null/no-null
+    last_name: 'DUPONT',
+    zip: '75001',
+    address: null, // eslint-disable-line no-null/no-null
+    birthday: '1980-08-26',
+    job: 'Computer analyst',
+    job_category: null, // eslint-disable-line no-null/no-null
+    job_category_details: null, // eslint-disable-line no-null/no-null
+    is_married: null, // eslint-disable-line no-null/no-null
+    is_owner: null, // eslint-disable-line no-null/no-null
+    nb_kids: null, // eslint-disable-line no-null/no-null
+  },
+];

--- a/src/aggregator/interfaces/bridge.interface.ts
+++ b/src/aggregator/interfaces/bridge.interface.ts
@@ -174,3 +174,22 @@ export interface BridgeCategory {
     resource_type: string;
   };
 }
+
+/**
+ * Bridge User Information
+ */
+export interface BridgeUserInformation {
+  item_id: number;
+  sex?: 'FEMALE' | 'MALE' | null;
+  first_name?: string | null;
+  last_name?: string | null;
+  zip?: string | null;
+  address?: string | null;
+  birthday?: Date | string | null;
+  job?: string | null;
+  job_category?: string | null; // @TODO: do we have an enum for that?
+  job_category_details?: string | null; // @TODO: do we have an enum for that?
+  is_married?: boolean | null;
+  is_owner?: boolean | null;
+  nb_kids?: number | null;
+}

--- a/src/aggregator/services/aggregator.service.spec.ts
+++ b/src/aggregator/services/aggregator.service.spec.ts
@@ -6,7 +6,7 @@ import { v4 as uuidV4 } from 'uuid';
 
 import { AlgoanModule } from '../../algoan/algoan.module';
 import { AppModule } from '../../app.module';
-import { mockAccount, mockTransaction, mockAuthResponse } from '../interfaces/bridge-mock';
+import { mockAccount, mockTransaction, mockAuthResponse, mockPersonalInformation } from '../interfaces/bridge-mock';
 import { AggregatorService } from './aggregator.service';
 import { BridgeClient } from './bridge/bridge.client';
 
@@ -176,5 +176,15 @@ describe('AggregatorService', () => {
     await service.getResourceName(token, resourceUri);
 
     expect(spy).toBeCalledWith(token, resourceUri, undefined);
+  });
+
+  it('should get the personal information from the user', async () => {
+    const spy = jest
+      .spyOn(client, 'getUserPersonalInformation')
+      .mockReturnValue(Promise.resolve(mockPersonalInformation));
+    const token = 'token';
+    await service.getUserPersonalInformation(token);
+
+    expect(spy).toBeCalledWith(token, undefined);
   });
 });

--- a/src/aggregator/services/aggregator.service.ts
+++ b/src/aggregator/services/aggregator.service.ts
@@ -2,7 +2,13 @@ import { createHmac } from 'crypto';
 import { Injectable } from '@nestjs/common';
 import { IBanksUser } from '@algoan/rest';
 import { config } from 'node-config-ts';
-import { UserAccount, BridgeAccount, BridgeTransaction, AuthenticationResponse } from '../interfaces/bridge.interface';
+import {
+  UserAccount,
+  BridgeAccount,
+  BridgeTransaction,
+  AuthenticationResponse,
+  BridgeUserInformation,
+} from '../interfaces/bridge.interface';
 import { BridgeClient, ClientConfig } from './bridge/bridge.client';
 
 /**
@@ -76,6 +82,16 @@ export class AggregatorService {
    */
   public async getResourceName(accessToken: string, bridgeUri: string, clientConfig?: ClientConfig): Promise<string> {
     return this.bridgeClient.getResourceName(accessToken, bridgeUri, clientConfig);
+  }
+
+  /**
+   * Returns the Bridge Personal information for a user
+   */
+  public async getUserPersonalInformation(
+    accessToken: string,
+    clientConfig?: ClientConfig,
+  ): Promise<BridgeUserInformation[]> {
+    return this.bridgeClient.getUserPersonalInformation(accessToken, clientConfig);
   }
 
   /**

--- a/src/aggregator/services/bridge/bridge.client.spec.ts
+++ b/src/aggregator/services/bridge/bridge.client.spec.ts
@@ -14,7 +14,7 @@ import {
   BridgeBank,
   BridgeAccount,
 } from '../../interfaces/bridge.interface';
-import { mockUserResponse, mockAuthResponse } from '../../interfaces/bridge-mock';
+import { mockUserResponse, mockAuthResponse, mockPersonalInformation } from '../../interfaces/bridge-mock';
 import { BridgeClient } from './bridge.client';
 
 describe('BridgeClient', () => {
@@ -294,6 +294,30 @@ describe('BridgeClient', () => {
     expect(resp).toBe('mockBankName');
 
     expect(spy).toHaveBeenCalledWith('https://sync.bankin.com/v2/mockResourceUri', {
+      headers: {
+        Authorization: 'Bearer mockAccessToken',
+        'Client-Id': config.bridge.clientId,
+        'Client-Secret': config.bridge.clientSecret,
+        'Bankin-Version': config.bridge.bankinVersion,
+      },
+    });
+  });
+
+  it('can get user information', async () => {
+    const result: AxiosResponse = {
+      data: mockPersonalInformation,
+      status: 200,
+      statusText: '',
+      headers: {},
+      config: {},
+    };
+
+    const spy = jest.spyOn(httpService, 'get').mockImplementationOnce(() => of(result));
+
+    const resp = await service.getUserPersonalInformation('mockAccessToken');
+    expect(resp).toEqual(mockPersonalInformation);
+
+    expect(spy).toHaveBeenCalledWith('https://sync.bankin.com/v2/users/kyc', {
       headers: {
         Authorization: 'Bearer mockAccessToken',
         'Client-Id': config.bridge.clientId,

--- a/src/aggregator/services/bridge/bridge.client.ts
+++ b/src/aggregator/services/bridge/bridge.client.ts
@@ -12,6 +12,7 @@ import {
   BridgeTransaction,
   BridgeBank,
   BridgeCategory,
+  BridgeUserInformation,
 } from '../../interfaces/bridge.interface';
 
 /**
@@ -185,6 +186,22 @@ export class BridgeClient {
         },
       })
       .toPromise();
+  }
+
+  /**
+   * Get user personal information
+   */
+  public async getUserPersonalInformation(
+    accessToken: string,
+    clientConfig?: ClientConfig,
+  ): Promise<BridgeUserInformation[]> {
+    const url: string = `${config.bridge.baseUrl}/v2/users/kyc`;
+
+    const resp: AxiosResponse<BridgeUserInformation[]> = await this.httpService
+      .get(url, { headers: { Authorization: `Bearer ${accessToken}`, ...BridgeClient.getHeaders(clientConfig) } })
+      .toPromise();
+
+    return resp.data;
   }
 
   /**

--- a/src/aggregator/services/bridge/bridge.utils.spec.ts
+++ b/src/aggregator/services/bridge/bridge.utils.spec.ts
@@ -10,7 +10,7 @@ import {
 import { BridgeAccount } from '../../interfaces/bridge.interface';
 import { AggregatorModule } from '../../aggregator.module';
 import { AggregatorService } from '../aggregator.service';
-import { mockAccount, mockTransaction } from '../../interfaces/bridge-mock';
+import { mockAccount, mockPersonalInformation, mockTransaction } from '../../interfaces/bridge-mock';
 import { AlgoanModule } from '../../../algoan/algoan.module';
 import { AppModule } from '../../../app.module';
 import { mapBridgeAccount, mapBridgeTransactions } from './bridge.utils';
@@ -54,10 +54,18 @@ describe('Bridge Utils', () => {
         status: 'ACTIVE',
         type: AccountType.CREDIT_CARD,
         usage: UsageType.PERSONAL,
+        owner: {
+          name: 'MISTER  DUPONT',
+        },
       },
     ];
 
-    const mappedAccount = await mapBridgeAccount([mockAccount], 'mockAccessToken', aggregatorService);
+    const mappedAccount = await mapBridgeAccount(
+      [mockAccount],
+      mockPersonalInformation,
+      'mockAccessToken',
+      aggregatorService,
+    );
 
     expect(aggregatorSpy).toHaveBeenCalledWith('mockAccessToken', mockAccount.bank.resource_uri, undefined);
     expect(mappedAccount).toEqual(expectedAccounts);

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -14,7 +14,12 @@ import { UnauthorizedException, Injectable, Logger } from '@nestjs/common';
 
 import { AlgoanService } from '../../algoan/algoan.service';
 import { AggregatorService } from '../../aggregator/services/aggregator.service';
-import { AuthenticationResponse, BridgeAccount, BridgeTransaction } from '../../aggregator/interfaces/bridge.interface';
+import {
+  AuthenticationResponse,
+  BridgeAccount,
+  BridgeTransaction,
+  BridgeUserInformation,
+} from '../../aggregator/interfaces/bridge.interface';
 import { mapBridgeAccount, mapBridgeTransactions } from '../../aggregator/services/bridge/bridge.utils';
 import { EventDTO } from '../dto/event.dto';
 import { BankreaderLinkRequiredDTO } from '../dto/bandreader-link-required.dto';
@@ -197,8 +202,18 @@ export class HooksService {
       message: `Bridge accounts retrieved for Banks User "${banksUser.id}"`,
       accounts,
     });
+
+    /**
+     * 2.b. Get personal information
+     */
+    const userInfo: BridgeUserInformation[] = await this.aggregator.getUserPersonalInformation(
+      accessToken,
+      serviceAccount.config as ClientConfig,
+    );
+
     const algoanAccounts: PostBanksUserAccountDTO[] = await mapBridgeAccount(
       accounts,
+      userInfo,
       accessToken,
       this.aggregator,
       serviceAccount.config as ClientConfig,

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -206,10 +206,12 @@ export class HooksService {
     /**
      * 2.b. Get personal information
      */
-    const userInfo: BridgeUserInformation[] = await this.aggregator.getUserPersonalInformation(
-      accessToken,
-      serviceAccount.config as ClientConfig,
-    );
+    let userInfo: BridgeUserInformation[] = [];
+    try {
+      userInfo = await this.aggregator.getUserPersonalInformation(accessToken, serviceAccount.config as ClientConfig);
+    } catch (err) {
+      this.logger.warn({ message: `Unable to get user personal information`, error: err });
+    }
 
     const algoanAccounts: PostBanksUserAccountDTO[] = await mapBridgeAccount(
       accounts,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Fetch user personal information from the user connection (`item`) and add the `owner.name` to each account based on its connection (`item.id` / `item_id`).

#### Note

- Requires https://github.com/algoan/rest-nodejs/pull/34

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)