### PR TITLE
[FEAT] Handle refresh of connection

### DIFF
--- a/src/aggregator/interfaces/bridge-mock.ts
+++ b/src/aggregator/interfaces/bridge-mock.ts
@@ -1,11 +1,12 @@
 import {
+  AuthenticationResponse,
   BridgeAccount,
   BridgeAccountStatus,
   BridgeAccountType,
+  BridgeRefreshStatus,
   BridgeTransaction,
-  UserResponse,
-  AuthenticationResponse,
   BridgeUserInformation,
+  UserResponse,
 } from './bridge.interface';
 
 export const mockAccount: BridgeAccount = {
@@ -116,3 +117,11 @@ export const mockPersonalInformation: BridgeUserInformation[] = [
     nb_kids: null, // eslint-disable-line no-null/no-null
   },
 ];
+
+export const mockRefreshStatus: BridgeRefreshStatus = {
+  status: 'finished',
+  refresh_at: new Date().toISOString(),
+  mfa: null, // eslint-disable-line no-null/no-null
+  refresh_accounts_count: 0,
+  total_accounts_count: 0,
+};

--- a/src/aggregator/interfaces/bridge.interface.ts
+++ b/src/aggregator/interfaces/bridge.interface.ts
@@ -193,3 +193,15 @@ export interface BridgeUserInformation {
   is_owner?: boolean | null;
   nb_kids?: number | null;
 }
+
+/**
+ * Status of a refresh
+ * https://docs.bridgeapi.io/reference#get-a-refresh-status
+ */
+export interface BridgeRefreshStatus {
+  status: string;
+  refresh_at: Date | string;
+  mfa?: Record<string, unknown> | null;
+  refresh_accounts_count?: number | null;
+  total_accounts_count?: number | null;
+}

--- a/src/aggregator/services/aggregator.service.spec.ts
+++ b/src/aggregator/services/aggregator.service.spec.ts
@@ -1,11 +1,16 @@
 import { CacheModule, HttpModule, HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { createHmac } from 'crypto';
-import { customerMock } from '../../algoan/dto/customer.objects.mock';
-
 import { AlgoanModule } from '../../algoan/algoan.module';
+import { customerMock } from '../../algoan/dto/customer.objects.mock';
 import { AppModule } from '../../app.module';
-import { mockAccount, mockAuthResponse, mockPersonalInformation, mockTransaction } from '../interfaces/bridge-mock';
+import {
+  mockAccount,
+  mockAuthResponse,
+  mockPersonalInformation,
+  mockRefreshStatus,
+  mockTransaction,
+} from '../interfaces/bridge-mock';
 import { AggregatorService } from './aggregator.service';
 import { BridgeClient } from './bridge/bridge.client';
 
@@ -180,6 +185,24 @@ describe('AggregatorService', () => {
     it('should not try to re-create an item when there is one already', async () => {
       // TODO
     });
+  });
+
+  it('should refresh an item', async () => {
+    const spy = jest.spyOn(client, 'refreshItem').mockReturnValue(Promise.resolve());
+    const itemId = 'mockItemId';
+    const token = 'mockToken';
+    await service.refresh(itemId, token);
+
+    expect(spy).toBeCalledWith(itemId, token, undefined);
+  });
+
+  it('should refresh an item', async () => {
+    const spy = jest.spyOn(client, 'getRefreshStatus').mockReturnValue(Promise.resolve(mockRefreshStatus));
+    const itemId = 'mockItemId';
+    const token = 'mockToken';
+    await service.getRefreshStatus(itemId, token);
+
+    expect(spy).toBeCalledWith(itemId, token, undefined);
   });
 
   it('should get the accounts', async () => {

--- a/src/aggregator/services/aggregator.service.ts
+++ b/src/aggregator/services/aggregator.service.ts
@@ -1,10 +1,10 @@
 import { createHmac } from 'crypto';
 import { HttpStatus, Injectable } from '@nestjs/common';
 import { config } from 'node-config-ts';
-
 import {
   AuthenticationResponse,
   BridgeAccount,
+  BridgeRefreshStatus,
   BridgeTransaction,
   BridgeUserInformation,
   UserAccount,
@@ -17,6 +17,28 @@ import { BridgeClient, ClientConfig } from './bridge/bridge.client';
 @Injectable()
 export class AggregatorService {
   constructor(private readonly bridgeClient: BridgeClient) {}
+
+  /**
+   * Refresh a connection
+   * @param id id of the connection
+   * @param accessToken access token of the connection
+   */
+  public async refresh(id: string | number, accessToken: string, clientConfig?: ClientConfig): Promise<void> {
+    return this.bridgeClient.refreshItem(id, accessToken, clientConfig);
+  }
+
+  /**
+   * Get the status of the refresh of a connection
+   * @param id id of the connection
+   * @param accessToken access token of the connection
+   */
+  public async getRefreshStatus(
+    id: string | number,
+    accessToken: string,
+    clientConfig?: ClientConfig,
+  ): Promise<BridgeRefreshStatus> {
+    return this.bridgeClient.getRefreshStatus(id, accessToken, clientConfig);
+  }
 
   /**
    * Create the Bridge Webview url base on the client and it's callbackUrl

--- a/src/aggregator/services/bridge/bridge.client.ts
+++ b/src/aggregator/services/bridge/bridge.client.ts
@@ -1,19 +1,20 @@
-import { CACHE_MANAGER, Inject, HttpService, Injectable, Logger } from '@nestjs/common';
-import { Cache } from 'cache-manager';
-import { config } from 'node-config-ts';
+import { CACHE_MANAGER, HttpService, Inject, Injectable, Logger } from '@nestjs/common';
 import { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { Cache } from 'cache-manager';
 import { isNil } from 'lodash';
+import { config } from 'node-config-ts';
 import {
-  UserResponse,
-  UserAccount,
   AuthenticationResponse,
-  ConnectItemResponse,
-  ListResponse,
   BridgeAccount,
-  BridgeTransaction,
   BridgeBank,
   BridgeCategory,
+  BridgeRefreshStatus,
+  BridgeTransaction,
   BridgeUserInformation,
+  ConnectItemResponse,
+  ListResponse,
+  UserAccount,
+  UserResponse,
 } from '../../interfaces/bridge.interface';
 
 /**
@@ -110,6 +111,32 @@ export class BridgeClient {
     }
 
     const resp: AxiosResponse<ConnectItemResponse> = await this.httpService
+      .get(url, { headers: { Authorization: `Bearer ${accessToken}`, ...BridgeClient.getHeaders(clientConfig) } })
+      .toPromise();
+
+    return resp.data;
+  }
+
+  /**
+   * Refresh an item
+   */
+  public async refreshItem(id: string | number, accessToken: string, clientConfig?: ClientConfig): Promise<void> {
+    const url: string = `${config.bridge.baseUrl}/v2/items/${id}/refresh`;
+    await this.httpService
+      .post(url, { headers: { Authorization: `Bearer ${accessToken}`, ...BridgeClient.getHeaders(clientConfig) } })
+      .toPromise();
+  }
+
+  /**
+   * Get status of a refresh
+   */
+  public async getRefreshStatus(
+    id: string | number,
+    accessToken: string,
+    clientConfig?: ClientConfig,
+  ): Promise<BridgeRefreshStatus> {
+    const url: string = `${config.bridge.baseUrl}/v2/items/${id}/refresh/status`;
+    const resp: AxiosResponse<BridgeRefreshStatus> = await this.httpService
       .get(url, { headers: { Authorization: `Bearer ${accessToken}`, ...BridgeClient.getHeaders(clientConfig) } })
       .toPromise();
 


### PR DESCRIPTION
- Refresh a connection to get the banks details based on an item's id.
- Question: I think I forget to save the item's id in the customer during the first run of the bank details event. Should I add it to `customer.aggregationDetails.userId`? 