### PR TITLE
fix(redirect-url): fix wrong parsing of callbackUrl containing params

### DIFF
--- a/src/aggregator/services/aggregator.service.spec.ts
+++ b/src/aggregator/services/aggregator.service.spec.ts
@@ -185,6 +185,39 @@ describe('AggregatorService', () => {
     it('should not try to re-create an item when there is one already', async () => {
       // TODO
     });
+
+    it('should extract correct context when callbackUrl contains query params', async () => {
+      const registerSpy = jest.spyOn(client, 'register').mockResolvedValueOnce({
+        uuid: '79c8961c-bdf7-11e5-88a3-4f2c2aec0665',
+        resource_type: 'user',
+        resource_uri: '/v2/users/79c8961c-bdf7-11e5-88a3-4f2c2aec0665',
+        email: 'john.doe@email.com',
+      });
+      const authenticateSpy = jest.spyOn(client, 'authenticate').mockResolvedValueOnce({
+        access_token: 'access-token',
+        expires_at: '2019-05-06T11:08:25.040Z',
+        user: {
+          uuid: 'c2a26c9e-dc23-4f67-b887-bbae0f26c415',
+          resource_uri: '/v2/users/c2a26c9e-dc23-4f67-b887-bbae0f26c415',
+          resource_type: 'user',
+          email: 'john.doe@email.com',
+        },
+      });
+      const connectItemSpy = jest.spyOn(client, 'connectItem').mockResolvedValueOnce({
+        redirect_url: 'https://bridge/redirection-url',
+      });
+
+      await service.generateRedirectUrl(
+        customerMock.id,
+        'https://domain.com/callback?param=1',
+      );
+      expect(connectItemSpy).toHaveBeenCalledWith(
+        'access-token',
+        "callback",
+        undefined,
+        undefined,
+      );
+    });
   });
 
   it('should refresh an item', async () => {

--- a/src/aggregator/services/aggregator.service.spec.ts
+++ b/src/aggregator/services/aggregator.service.spec.ts
@@ -209,11 +209,11 @@ describe('AggregatorService', () => {
 
       await service.generateRedirectUrl(
         customerMock.id,
-        'https://domain.com/callback?param=1',
+        'https://domain.com/call-back?param=1',
       );
       expect(connectItemSpy).toHaveBeenCalledWith(
         'access-token',
-        "callback",
+        "callzback",
         undefined,
         undefined,
       );

--- a/src/aggregator/services/aggregator.service.ts
+++ b/src/aggregator/services/aggregator.service.ts
@@ -73,7 +73,10 @@ export class AggregatorService {
     if (splittedCbUrl === undefined) {
       throw new Error('No callbackUrl provided');
     }
-    const uuid: string = splittedCbUrl[splittedCbUrl.length - 1].replace(/-/g, 'z');
+
+    const lastUrlSegment: string = splittedCbUrl[splittedCbUrl.length - 1];
+    const lastUrlSegmentWithoutQueryParams: string = lastUrlSegment.split('?')[0];
+    const uuid: string = lastUrlSegmentWithoutQueryParams.replace(/-/g, 'z');
 
     const redirectResponse = await this.bridgeClient.connectItem(
       authenticationResponse.access_token,


### PR DESCRIPTION
During redirect url generation, if the callbackUrl contains query params, the context sent to Bridge contains `?`. But this character is forbidden and thus, Bridge API returns an error.