### PR TITLE
feat: handle iframe mode

### DIFF
--- a/src/algoan/dto/customer.enums.ts
+++ b/src/algoan/dto/customer.enums.ts
@@ -4,6 +4,7 @@
 export enum AggregationDetailsMode {
   REDIRECT = 'REDIRECT',
   API = 'API',
+  IFRAME = 'IFRAME',
 }
 
 /**

--- a/src/algoan/dto/customer.objects.ts
+++ b/src/algoan/dto/customer.objects.ts
@@ -20,6 +20,7 @@ export interface AggregationDetails {
   mode?: AggregationDetailsMode;
   redirectUrl?: string;
   apiUrl?: string;
+  iframeUrl?: string;
   userId?: string;
   clientId?: string;
 }

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -160,6 +160,15 @@ export class HooksService {
         );
         break;
 
+      case AggregationDetailsMode.IFRAME:
+        aggregationDetails.iframeUrl = await this.aggregator.generateRedirectUrl(
+          customer.id,
+          customer.aggregationDetails?.callbackUrl,
+          customer.personalDetails?.contact?.email,
+          serviceAccount.config as ClientConfig,
+        );
+        break;
+
       default:
         throw new Error(`Invalid bank connection mode ${customer.aggregationDetails?.mode}`);
     }


### PR DESCRIPTION
# Documentation

Implement the iframe mode. Actually, Bridge doesn't provide a [postMessage API](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to integrate a "real" iframe integration of their page. However, it is possible to embed the same page as the one of the redirect mode within an iframe. That is why the `iframeUrl` is the same as the `redirectUrl`.