### PR TITLE
feat(bridge.client): add the parent_url to Bridge widget

### DIFF
--- a/src/aggregator/interfaces/bridge.interface.ts
+++ b/src/aggregator/interfaces/bridge.interface.ts
@@ -9,6 +9,7 @@ export interface BrideConnectItemDTO {
   context?: string;
   bank_id?: number;
   capabilities?: string;
+  parent_url?: string;
 }
 
 /**

--- a/src/aggregator/services/bridge/bridge.client.spec.ts
+++ b/src/aggregator/services/bridge/bridge.client.spec.ts
@@ -23,7 +23,7 @@ import {
   ConnectItemResponse,
   ListResponse,
 } from '../../interfaces/bridge.interface';
-import { BridgeClient } from './bridge.client';
+import { BridgeClient, ClientConfig } from './bridge.client';
 
 describe('BridgeClient', () => {
   let service: BridgeClient;
@@ -210,6 +210,48 @@ describe('BridgeClient', () => {
         prefill_email: email,
         context: uuid,
         country: 'fr',
+      },
+      {
+        headers: {
+          Authorization: 'Bearer secret-access-token',
+          'Client-Id': config.bridge.clientId,
+          'Client-Secret': config.bridge.clientSecret,
+          'Bankin-Version': config.bridge.bankinVersion,
+        },
+      },
+    );
+  });
+
+  it('can connect a user to an item with a parent url', async () => {
+    const email: string = 'test@test.com';
+    const connectItemResponse: ConnectItemResponse = {
+      redirect_url: 'the-redirect-url',
+    };
+    const result: AxiosResponse = {
+      data: connectItemResponse,
+      status: 200,
+      statusText: '',
+      headers: {},
+      config: {},
+    };
+    const clientConfig: ClientConfig = {
+      clientId: config.bridge.clientId,
+      clientSecret: config.bridge.clientSecret,
+      bankinVersion: config.bridge.bankinVersion,
+      parentUrl: 'https://fake-url.fake',
+    };
+    const spy = jest.spyOn(httpService, 'post').mockImplementationOnce(() => of(result));
+    const uuid: string = uuidV4().replace(/-/g, 'z');
+    const resp = await service.connectItem('secret-access-token', uuid, email, clientConfig);
+    expect(resp).toBe(connectItemResponse);
+
+    expect(spy).toHaveBeenCalledWith(
+      `https://api.bridgeapi.io/v2/connect/items/add`,
+      {
+        prefill_email: email,
+        context: uuid,
+        country: 'fr',
+        parent_url: clientConfig.parentUrl,
       },
       {
         headers: {

--- a/src/aggregator/services/bridge/bridge.client.ts
+++ b/src/aggregator/services/bridge/bridge.client.ts
@@ -30,6 +30,7 @@ export interface ClientConfig {
   bankinVersion: string;
   nbOfMonths?: number;
   deleteBridgeUsers?: boolean;
+  parentUrl?: string;
 }
 
 /**
@@ -112,6 +113,7 @@ export class BridgeClient {
       country: 'fr',
       context,
       prefill_email: email,
+      parent_url: clientConfig?.parentUrl,
     };
     const resp: AxiosResponse<ConnectItemResponse> = await BridgeClient.toPromise(
       this.httpService.post(url, data, {


### PR DESCRIPTION
### Description

Bridge just released a new parameter in order to secure their iframe: `parent_url` according to [their documentation](https://docs.bridgeapi.io/docs/use-bridge-connect-in-iframes).

- Add `parentUrl` to client config so we can authorize an iframe to be hosted