### PR TITLE
[FIX] update the lastUpdatedAt value

### DIFF
--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -267,6 +267,13 @@ export class HooksService {
         );
 
         transactions = transactions.concat(fetchedTransactions);
+        lastUpdatedAt = fetchedTransactions[0]?.updated_at ?? lastUpdatedAt;
+        for (const transaction of fetchedTransactions) {
+          if (moment(transaction.updated_at).isAfter(lastUpdatedAt)) {
+            lastUpdatedAt = transaction.updated_at;
+          }
+        }
+
         // Sort transactions by date
         transactions = transactions.sort((tr1: BridgeTransaction, tr2: BridgeTransaction) =>
           /* eslint-disable no-magic-numbers */


### PR DESCRIPTION
## Description 
- The variable lastUpdatedAt was defined but never assigned (the assignment was removed when migrating from V1 algoan support to V2
- Without the correct value for this variable, if the customer doesn't have 3 months history of transactions  we will keep calling the /transactions route without the lastUpdatedAt parameter and get the same data again and again and post duplicated transactions in the analysis. 

