### PR TITLE
[FEAT] Replace the context returned by the custom identifier 

### DIFF
--- a/src/aggregator/services/aggregator.service.ts
+++ b/src/aggregator/services/aggregator.service.ts
@@ -52,6 +52,7 @@ export class AggregatorService {
     callbackUrl?: string,
     email?: string,
     clientConfig?: ClientConfig,
+    customIdentifier?: string,
   ): Promise<string> {
     const userAccount: UserAccount = AggregatorService.buildCredentials(id);
     try {
@@ -82,6 +83,7 @@ export class AggregatorService {
       uuid,
       email,
       clientConfig,
+      customIdentifier,
     );
 
     return redirectResponse.redirect_url;

--- a/src/aggregator/services/bridge/bridge.client.spec.ts
+++ b/src/aggregator/services/bridge/bridge.client.spec.ts
@@ -172,7 +172,6 @@ describe('BridgeClient', () => {
     expect(spy).toHaveBeenCalledWith(
       `https://api.bridgeapi.io/v2/connect/items/add`,
       {
-        context: uuid,
         country: 'fr',
       },
       {
@@ -208,7 +207,6 @@ describe('BridgeClient', () => {
       `https://api.bridgeapi.io/v2/connect/items/add`,
       {
         prefill_email: email,
-        context: uuid,
         country: 'fr',
       },
       {
@@ -249,7 +247,6 @@ describe('BridgeClient', () => {
       `https://api.bridgeapi.io/v2/connect/items/add`,
       {
         prefill_email: email,
-        context: uuid,
         country: 'fr',
         parent_url: clientConfig.parentUrl,
       },
@@ -304,7 +301,7 @@ describe('BridgeClient', () => {
     );
   });
 
-  it('can connect a user to an item an remove special characters from context', async () => {
+  it('can connect a user to an item with customIdentifier', async () => {
     const email: string = 'test@test.com';
     const connectItemResponse: ConnectItemResponse = {
       redirect_url: 'the-redirect-url',
@@ -323,18 +320,17 @@ describe('BridgeClient', () => {
       parentUrl: 'https://fake-url.fake',
     };
     const spy = jest.spyOn(httpService, 'post').mockImplementationOnce(() => of(result));
-    const uuid: string = 'tesT5-7&/é';
-    const cleanUuid: string = 'tesT57';
-    const resp = await service.connectItem('secret-access-token', uuid, email, clientConfig);
+    const uuid: string = uuidV4().replace(/-/g, 'z');
+    const resp = await service.connectItem('secret-access-token', uuid, email, clientConfig, 'customIdentifier');
     expect(resp).toBe(connectItemResponse);
 
     expect(spy).toHaveBeenCalledWith(
       `https://api.bridgeapi.io/v2/connect/items/add`,
       {
+        context: 'customIdentifier',
         prefill_email: email,
         country: 'fr',
         parent_url: clientConfig.parentUrl,
-        context: cleanUuid,
       },
       {
         headers: {

--- a/src/aggregator/services/bridge/bridge.client.ts
+++ b/src/aggregator/services/bridge/bridge.client.ts
@@ -107,6 +107,7 @@ export class BridgeClient {
     context?: string,
     email?: string,
     clientConfig?: ClientConfig,
+    customIdentifier?: string,
   ): Promise<ConnectItemResponse> {
     const url: string = `${config.bridge.baseUrl}/v2/connect/items/add`;
     const data: BrideConnectItemDTO = {
@@ -115,11 +116,8 @@ export class BridgeClient {
       parent_url: clientConfig?.parentUrl,
     };
 
-    if (context !== undefined) {
-      const cleanContext = context.replace(/[^a-zA-Z0-9]/g, '');
-      if (cleanContext !== '') {
-        data.context = cleanContext;
-      }
+    if (customIdentifier !== undefined) {
+      data.context = customIdentifier;
     }
 
     const resp: AxiosResponse<ConnectItemResponse> = await BridgeClient.toPromise(

--- a/src/hooks/services/hooks.service.spec.ts
+++ b/src/hooks/services/hooks.service.spec.ts
@@ -162,6 +162,7 @@ describe('HooksService', () => {
       customerMock.aggregationDetails?.callbackUrl,
       customerMock.personalDetails?.contact?.email,
       mockServiceAccountConfig,
+      customerMock.customIdentifier,
     );
     expect(updateCustomerSpy).toBeCalledWith(customerMock.id, {
       aggregationDetails: { aggregatorName: 'BRIDGE', redirectUrl: 'mockRedirectUrl' },
@@ -190,6 +191,7 @@ describe('HooksService', () => {
       customerMock.aggregationDetails?.callbackUrl,
       customerMock.personalDetails?.contact?.email,
       mockServiceAccountConfig,
+      customerMock.customIdentifier,
     );
     expect(updateCustomerSpy).toBeCalledWith(customerMock.id, {
       aggregationDetails: { aggregatorName: 'BRIDGE', iframeUrl: 'mockRedirectUrl' },

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -157,6 +157,7 @@ export class HooksService {
           customer.aggregationDetails?.callbackUrl,
           customer.personalDetails?.contact?.email,
           serviceAccount.config as ClientConfig,
+          customer.customIdentifier,
         );
         break;
 
@@ -166,6 +167,7 @@ export class HooksService {
           customer.aggregationDetails?.callbackUrl,
           customer.personalDetails?.contact?.email,
           serviceAccount.config as ClientConfig,
+          customer.customIdentifier,
         );
         break;
 


### PR DESCRIPTION
## Description

In this PR, we replaced the context that we return in the redirect link with the custom identifier. We are going to use this context to get the customer in the api bff in case the user changes his web browser.


[Link to the US](https://www.notion.so/algoanteam/Current-Sprint-ca48385a8ecd4c559422e85eddf5fb7a?p=6454cd74b55f4aef9cde9cd6f7a88044&pm=s)