### PR TITLE
[FIX] stop retrieving transactions if no new transactions

### DIFF
--- a/src/hooks/services/hooks.service.spec.ts
+++ b/src/hooks/services/hooks.service.spec.ts
@@ -347,6 +347,143 @@ describe('HooksService', () => {
     expect(deleteUserSpy).toHaveBeenCalledTimes(0);
   });
 
+  it('synchronizes the accounts on bank details required and exit ', async () => {
+    const algoanAuthenticateSpy = jest.spyOn(algoanHttpService, 'authenticate').mockReturnValue();
+    const getCustomerSpy = jest.spyOn(algoanCustomerService, 'getCustomerById').mockResolvedValue(customerMock);
+    const updateAnalysisSpy = jest.spyOn(algoanAnalysisService, 'updateAnalysis').mockResolvedValue(analysisMock);
+    mockServiceAccount.config = mockServiceAccountConfig;
+    const accessTokenSpy = jest.spyOn(aggregatorService, 'getAccessToken').mockResolvedValue({
+      access_token: 'mockPermToken',
+      expires_at: '323423423423',
+      user: { email: 'test@test.com', uuid: 'rrr' },
+    });
+    const accountSpy = jest.spyOn(aggregatorService, 'getAccounts').mockResolvedValue([
+      { ...mockAccount, type: BridgeAccountType.CHECKING },
+      { ...mockAccount, id: 0 },
+    ]);
+    const userInfoSpy = jest
+      .spyOn(aggregatorService, 'getUserPersonalInformation')
+      .mockResolvedValue(mockPersonalInformation);
+    const date = new Date().toISOString();
+    const transactionSpy = jest
+      .spyOn(aggregatorService, 'getTransactions')
+      .mockResolvedValueOnce([{ ...mockTransaction, date, account_id: mockAccount.id }])
+      .mockResolvedValue([]);
+    const bankInformationSpy = jest
+      .spyOn(aggregatorService, 'getBankInformation')
+      .mockResolvedValue({ name: 'mockBankName' });
+    const resourceNameSpy = jest.spyOn(aggregatorService, 'getResourceName').mockResolvedValue('mockResourceName');
+    const deleteUserSpy = jest.spyOn(aggregatorService, 'deleteUser').mockResolvedValue();
+
+    const mockEventPayload = {
+      customerId: customerMock.id,
+      analysisId: analysisMock.id,
+      temporaryCode: 'mockTemporaryToken',
+    };
+
+    await hooksService.handleBankDetailsRequiredEvent(mockServiceAccount, mockEventPayload, new Date());
+
+    expect(algoanAuthenticateSpy).toBeCalledWith(mockServiceAccount.clientId, mockServiceAccount.clientSecret);
+    expect(getCustomerSpy).toBeCalledWith(mockEventPayload.customerId);
+    expect(updateAnalysisSpy).toBeCalledWith(customerMock.id, mockEventPayload.analysisId, {
+      accounts: [
+        {
+          aggregator: {
+            id: '1234',
+          },
+          balance: 100,
+          balanceDate: '2019-04-06T13:53:12.000Z',
+          bank: {
+            id: '6',
+            name: 'mockBankName',
+          },
+          bic: undefined,
+          currency: 'USD',
+          details: {
+            loan: {
+              amount: 140200,
+              endDate: '2026-12-30T23:00:00.000Z',
+              interestRate: 0.0125,
+              payment: 1000,
+              remainingCapital: 100000,
+              startDate: '2013-01-09T23:00:00.000Z',
+              type: 'OTHER',
+            },
+            savings: undefined,
+          },
+          iban: 'mockIban',
+          name: 'mockBridgeAccountName',
+          owners: [
+            {
+              name: ' DUPONT',
+            },
+          ],
+          type: 'CHECKING',
+          usage: 'PERSONAL',
+          transactions: [
+            {
+              aggregator: {
+                category: 'mockResourceName',
+                id: '23',
+              },
+              amount: 30,
+              currency: 'USD',
+              dates: {
+                bookedAt: undefined,
+                debitedAt: date,
+              },
+              description: 'mockRawDescription',
+              isComing: false,
+            },
+          ],
+        },
+        {
+          aggregator: {
+            id: '0',
+          },
+          balance: 100,
+          balanceDate: '2019-04-06T13:53:12.000Z',
+          bank: {
+            id: '6',
+            name: 'mockBankName',
+          },
+          bic: undefined,
+          currency: 'USD',
+          details: {
+            loan: {
+              amount: 140200,
+              endDate: '2026-12-30T23:00:00.000Z',
+              interestRate: 0.0125,
+              payment: 1000,
+              remainingCapital: 100000,
+              startDate: '2013-01-09T23:00:00.000Z',
+              type: 'OTHER',
+            },
+            savings: undefined,
+          },
+          iban: 'mockIban',
+          name: 'mockBridgeAccountName',
+          owners: [
+            {
+              name: ' DUPONT',
+            },
+          ],
+          type: 'CREDIT_CARD',
+          usage: 'PERSONAL',
+        },
+      ],
+    });
+
+    expect(accessTokenSpy).toBeCalledWith(customerMock.id, mockServiceAccountConfig);
+    expect(accountSpy).toBeCalledWith('mockPermToken', mockServiceAccountConfig);
+    expect(userInfoSpy).toBeCalledWith('mockPermToken', mockServiceAccountConfig);
+    expect(bankInformationSpy).toBeCalledTimes(2);
+    expect(resourceNameSpy).toBeCalledTimes(1);
+    expect(transactionSpy).toBeCalledTimes(2);
+    expect(transactionSpy).toBeCalledWith('mockPermToken', undefined, mockServiceAccountConfig);
+    expect(deleteUserSpy).toHaveBeenCalledTimes(0);
+  });
+
   it('refresh when userId is defined and synchronizes the accounts on bank details required', async () => {
     const algoanAuthenticateSpy = jest.spyOn(algoanHttpService, 'authenticate').mockReturnValue();
     const getCustomerSpy = jest.spyOn(algoanCustomerService, 'getCustomerById').mockResolvedValue({

--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -266,6 +266,10 @@ export class HooksService {
           saConfig,
         );
 
+        if (fetchedTransactions.length === 0) {
+          break;
+        }
+
         transactions = transactions.concat(fetchedTransactions);
         lastUpdatedAt = fetchedTransactions[0]?.updated_at ?? lastUpdatedAt;
         for (const transaction of fetchedTransactions) {


### PR DESCRIPTION
# Documentation
This pull request aims to fix a bug when a user has no transactions older than the date threshold. `today - (3 ?? nbOfMonths months)`

If a user has no transactions older than this date then the connector keeps sending the same request to bridge until the 5 min timeout even if the request returns an empty list. (cf screenshot)
![Screenshot 2023-01-30 at 18 54 03](https://user-images.githubusercontent.com/58176270/215555493-cdb90c21-0f5a-4209-a8d3-494ed3caee9e.png)
