### PR TITLE
[FIX] Stop fetching transactions if no new

### DIFF
--- a/src/hooks/services/hooks.service.ts
+++ b/src/hooks/services/hooks.service.ts
@@ -342,10 +342,13 @@ export class HooksService {
 
     let lastUpdatedAt: string | undefined;
     let firstTransactionDate: moment.Moment = moment();
+    let nbOfTransactions: number = 0;
     const transactionByAggregatorId: Map<string, BridgeTransaction> = new Map<string, BridgeTransaction>();
     const getUniqueKey = (transaction: BridgeTransaction): string => `${transaction.account_id}_${transaction.id}`;
 
     do {
+      nbOfTransactions = transactionByAggregatorId.size;
+
       const fetchedTransactions: BridgeTransaction[] = await this.aggregator.getTransactions(
         accessToken,
         lastUpdatedAt,
@@ -375,6 +378,7 @@ export class HooksService {
         }
       }
     } while (
+      nbOfTransactions < transactionByAggregatorId.size &&
       moment().diff(firstTransactionDate, 'months') <= nbOfMonths &&
       moment().isBefore(timeout) &&
       (await delay(this.config.bridge.synchronizationWaitingTime, { value: true }))


### PR DESCRIPTION
### Documentation

Stop fetching the transactions if no new one have been found in the last call. This is to prevent the connector from continuously fetching the same transactions and reach the (late) timeout to continue in the aggregation process.